### PR TITLE
Use API tokens instead of personal access keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,10 @@ This client has support for:
 
 ## Configuration
 
-1. Obtain API tokens and configuration from: <https://app.cinode.com/yourcompany/account>
+1. Enable the Cinode REST API for your company ([docs](https://support.cinode.com/en/articles/3994666-cinode-rest-api))
+1. Create a Cinode user and give it the roles "Api" and "Manager" in <https://app.cinode.com/polarsquad/administration/users/employees/>
     - The `yourcompany` part of the URL is your company name in the configuration
+1. Create a Cinode token for the bot user in <https://app.cinode.com/polarsquad/administration/integrations/tokens>
 1. Import and configure the client:
 
     ```typescript
@@ -31,8 +33,7 @@ This client has support for:
         name: 'yourcompany'     // Company name
       },
       clientBuilder(
-        'cinodeaccessid',       // Cinode Access ID
-        'cinodeaccessecret'     // Cinode Access Secret
+        'cinodeapitoken',       // Cinode API token
       )
     )
     const service = new CinodeService(api)
@@ -60,7 +61,7 @@ This client has support for:
 
 ## Links
 
-- [Official Cinode API documentation](https://api.cinode.com/docs/index.html)
+- [Official Cinode API documentation](https://api.cinode.app/docs/index.html)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,3 @@ This client has support for:
 ## License
 
 See [LICENSE](./LICENSE) for more details.
-
-## TODO
-
-- Use static (JWT) tokens for the API instead of personal ones

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,18 +1,12 @@
 import got from 'got';
-import jwt_decode from 'jwt-decode';
+import jwt_decode, { JwtPayload } from 'jwt-decode';
 import moment from 'moment';
 import Bottleneck from 'bottleneck';
 
-const CINODE_API_URL = 'https://api.cinode.com';
-
-// Persist session between the requests
-const session: {
-  access_token?: string;
-  refresh_token?: string;
-} = {};
+const CINODE_API_URL = 'https://api.cinode.app';
 
 // See your limits:
-// https://app.cinode.com/COMPANYNAME/administration/integrations/api
+// https://app.cinode.app/COMPANYNAME/administration/integrations/api
 const MAX_REQUESTS_TIME = 2000;
 const MAX_REQUESTS_IN_TIME = 35; // Actually 40, but we hit the limit sometimes
 
@@ -24,58 +18,24 @@ const limiter = new Bottleneck({
 
 function isValidJwtToken(token: string): boolean {
   try {
-    // not a fan of casting to `any`, but it works, seems like an issue with the third-party library
-    return moment.unix((jwt_decode(token) as any).exp).isAfter();
+    return moment.unix(jwt_decode<JwtPayload>(token).exp).isAfter();
   } catch (e) {
     return false;
   }
 }
 
-export default (accessId: string, accessSecret: string) =>
+export default (apiToken: string) =>
   got.extend({
     prefixUrl: CINODE_API_URL,
     hooks: {
       beforeRequest: [
-        // @ts-expect-error: TODO: fix this
-        // eslint-disable-next-line @typescript-eslint/no-empty-function
-        limiter.wrap(() => {}),
+        limiter.wrap(() => Promise.resolve()),
         async (options) => {
-          if (!session.access_token) {
-            try {
-              const { access_token, refresh_token } = await got
-                .get('token', {
-                  prefixUrl: CINODE_API_URL,
-                  username: accessId,
-                  password: accessSecret,
-                  hooks: {
-                    // beforeRequest: [console.log],
-                    beforeRedirect: [console.log],
-                  },
-                })
-                .json();
-              session.access_token = access_token;
-              session.refresh_token = refresh_token;
-              console.log('Authenticated to the Cinode API');
-            } catch (e) {
-              console.log('token fail', e);
-              throw e;
-            }
+          if (!isValidJwtToken(apiToken)) {
+            throw new Error('Cinode API token is expired!');
           }
 
-          if (!isValidJwtToken(session.access_token) && session.refresh_token) {
-            const { access_token, refresh_token } = await got
-              .post('token/refresh', {
-                prefixUrl: options.prefixUrl,
-                json: { refreshToken: session.refresh_token },
-              })
-              .json();
-
-            session.access_token = access_token;
-            session.refresh_token = refresh_token;
-            console.log('Refreshed Cinode API access token');
-          }
-
-          options.headers['Authorization'] = `Bearer ${session.access_token}`;
+          options.headers['Authorization'] = `Bearer ${apiToken}`;
         },
       ],
     },

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,4 +1,4 @@
-import got from 'got';
+import got, { Options } from 'got';
 import jwt_decode, { JwtPayload } from 'jwt-decode';
 import moment from 'moment';
 import Bottleneck from 'bottleneck';
@@ -29,14 +29,13 @@ export default (apiToken: string) =>
     prefixUrl: CINODE_API_URL,
     hooks: {
       beforeRequest: [
-        limiter.wrap(() => Promise.resolve()),
-        async (options) => {
+        limiter.wrap(async (options: Options) => {
           if (!isValidJwtToken(apiToken)) {
             throw new Error('Cinode API token is expired!');
           }
 
           options.headers['Authorization'] = `Bearer ${apiToken}`;
-        },
+        }),
       ],
     },
   });

--- a/src/client.ts
+++ b/src/client.ts
@@ -18,7 +18,7 @@ const limiter = new Bottleneck({
 
 function isValidJwtToken(token: string): boolean {
   try {
-    return moment.unix(jwt_decode<JwtPayload>(token).exp).isAfter();
+    return moment.unix(jwt_decode<JwtPayload>(token).exp || 0).isAfter();
   } catch (e) {
     return false;
   }

--- a/src/service.ts
+++ b/src/service.ts
@@ -28,8 +28,7 @@ import {
   onlyInTeams,
 } from './utils';
 
-// eslint-disable-next-line @typescript-eslint/no-empty-function
-const ignoreError = () => {};
+const ignoreError = () => undefined;
 
 const keywordMatch =
   (name: string) =>
@@ -142,9 +141,9 @@ export class CinodeService {
   getUserImageUrl = memoize(
     async (userId: number): Promise<string | undefined> => {
       const images = (await this.api.getUserImages(userId)) as Image[];
-      if (images.length) {
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        return getImageUrl(images.pop()!);
+      const lastImage = images.pop();
+      if (lastImage) {
+        return getImageUrl(lastImage);
       }
     },
     {

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,7 @@
 // NOTE:
 // This doesn't include all fields that are available through the API, only used.
 // Feel free to add the fields you need.
-// https://api.cinode.com/docs/index.html
+// https://api.cinode.app/docs/index.html
 
 export type Company = {
   id: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -85,8 +85,11 @@ export type WithProfile = {
 
 export type Profile = {
   skills: Skill[];
-  // eslint-disable-next-line @typescript-eslint/ban-types
-  employers: {}[];
+  employers: Employer[];
+};
+
+export type Employer = {
+  id: number | null;
 };
 
 export enum ContractType {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -44,16 +44,15 @@ const latelyChangedFirst = (a: Skill, b: Skill): number => {
   const aChangeDate = findLatestChangeDate(a);
   const bChangeDate = findLatestChangeDate(b);
 
-  if (!aChangeDate && !bChangeDate) {
+  if (aChangeDate && bChangeDate) {
+    return new Date(bChangeDate).getTime() - new Date(aChangeDate).getTime();
+  } else if (!aChangeDate && !bChangeDate) {
     return 0;
-  } else if (aChangeDate && !bChangeDate) {
+  } else if (aChangeDate) {
     return -1;
-  } else if (!aChangeDate && bChangeDate) {
+  } else {
     return 1;
   }
-
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  return new Date(bChangeDate!).getTime() - new Date(aChangeDate!).getTime();
 };
 
 const favouriteFirst = (a: Skill, b: Skill): number => {
@@ -188,7 +187,7 @@ export const isAway = (
 };
 
 export const getOrderedSkills = (user: User & WithProfile) => {
-  if (!user.profile.skills) {
+  if (!user.profile?.skills) {
     return [];
   }
   return user.profile.skills

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,7 +27,7 @@
     /* Strict Type-Checking Options */
     "strict": true /* Enable all strict type-checking options. */,
     "noImplicitAny": false /* Raise error on expressions and declarations with an implied 'any' type. */,
-    "strictNullChecks": false /* Enable strict null checks. */,
+    "strictNullChecks": true /* Enable strict null checks. */,
     // "strictFunctionTypes": true,                 /* Enable strict checking of function types. */
     // "strictBindCallApply": true,                 /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
     // "strictPropertyInitialization": true,        /* Enable strict checking of property initialization in classes. */


### PR DESCRIPTION
**This is a breaking change!**

This is the new and better way to authenticate to the Cinode API, as it isn't tied to any human-user. It also simplifies the API a bit as we don't need to manage refresh tokens etc.

This also requires a new endpoint: `https://api.cinode.app` instead of `https://api.cinode.com`.