### PR TITLE
Increase retries in API client and retry searches (POST)

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -60,4 +60,8 @@ export default (apiToken: string) =>
         }),
       ],
     },
+    retry: {
+      limit: 10,
+      maxRetryAfter: 600, // 10 min
+    },
   });


### PR DESCRIPTION
By default, `got` (the HTTP client we use) only retries a maximum of two times per requests and uses the request timeout as the maximum for `Retry-After` **AND** it doesn't (obviously) retry POST requests by default -> a lot of searches are not getting retried.

Increase the default limits and setup a special `got` client in the `Api` class for retryable POST requests.