### PR TITLE
Release v0.12.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@polarsquad/cinode-api",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@polarsquad/cinode-api",
-      "version": "0.12.2",
+      "version": "0.12.3",
       "license": "MIT",
       "dependencies": {
         "bottleneck": "^2.19.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polarsquad/cinode-api",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "description": "Cinode API for the Cinode platform",
   "homepage": "https://github.com/polarsquad/cinode-api#readme",
   "bugs": {


### PR DESCRIPTION
- Set up npm publish provenance
- Bump TypeScript to 5.x.x
- Bump `got` from 12.5.3 to 13.0.0
- Move `rimraf` to `devDependencies`
- Bump `devDependencies`