### PR TITLE
Allow filtering of projects in getAllProjects

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polarsquad/cinode-api",
-  "version": "0.12.5",
+  "version": "0.12.6",
   "description": "Cinode API for the Cinode platform",
   "homepage": "https://github.com/polarsquad/cinode-api#readme",
   "bugs": {

--- a/src/api.ts
+++ b/src/api.ts
@@ -25,6 +25,7 @@ import {
   ProjectBase,
   ProjectPipeline,
   ProjectState,
+  SearchProjectQuery,
   SearchResult,
   SearchSkillResult,
   TeamBase,
@@ -66,7 +67,7 @@ export class Api {
       .json<CompanyCustomer>();
   }
 
-  async listAllProjects(query = {}) {
+  async listAllProjects(query: SearchProjectQuery = {}) {
     const {
       pagedAndSortedBy: { itemsPerPage },
       totalItems,

--- a/src/service.ts
+++ b/src/service.ts
@@ -19,6 +19,7 @@ import type {
   ProjectBase,
   ProjectState,
   ProjectTeam,
+  SearchProjectQuery,
   UserFilter,
   WithProfile,
 } from './types.js';
@@ -69,8 +70,8 @@ export class CinodeService {
     this.backofficeTeams = backofficeTeams;
   }
 
-  async getAllProjects() {
-    const projects = await this.api.listAllProjects();
+  async getAllProjects(query: SearchProjectQuery = {}) {
+    const projects = await this.api.listAllProjects(query);
     return Promise.all(
       projects.flatMap((p) => (p?.id ? [this.getProject(p.id)] : []))
     );

--- a/src/types.ts
+++ b/src/types.ts
@@ -180,6 +180,21 @@ export enum ProjectState {
   Suspended = 60,
 }
 
+export enum SortByProject {
+  CreatedDateTime = 0,
+  Title = 1,
+  Identifier = 2,
+  CustomerIdentifier = 3,
+  SeoId = 4,
+  UpdatedDateTime = 5,
+  LastTouchDateTime = 6,
+}
+
+export enum SortOrder {
+  Ascending = 0,
+  Descending = 1,
+}
+
 export enum Status {
   Inactive = 0,
   Active = 1,
@@ -1265,6 +1280,27 @@ export interface Role {
   name?: string | null;
   description?: string | null;
   level?: AccessLevel | null;
+}
+
+interface PageAndSortByProject {
+  sortBy?: SortByProject;
+  sortOrder?: SortOrder;
+  page?: number;
+  itemsPerPage?: number;
+}
+
+export interface SearchProjectQuery {
+  title?: string;
+  identification?: string;
+  customerIdentifier?: string;
+  corporateIdentityNumber?: string;
+  customerId?: number;
+  pageAndSortBy?: PageAndSortByProject;
+  pipelines?: number[];
+  salesManagers?: number[];
+  customers?: number[];
+  intermediators?: number[];
+  projectStates?: ProjectState[];
 }
 
 export interface SearchSkill {


### PR DESCRIPTION
Add filtering option to getallProjects at service layer as currently it takes quite a long time to fetch all the projects when only some might be needed.